### PR TITLE
Fixed build on OSX and some compiler warnings

### DIFF
--- a/pspsh/pspsh.C
+++ b/pspsh/pspsh.C
@@ -974,8 +974,8 @@ int init_readline(void)
 #endif
 	rl_attempted_completion_function = shell_completion;
 	rl_callback_handler_install("", cli_handler);
-	rl_basic_word_break_characters = "\t\n ";
-	rl_completer_word_break_characters = "\t\n ";
+	rl_basic_word_break_characters = strdup("\t\n ");
+	rl_completer_word_break_characters = strdup("\t\n ");
 
 	return 1;
 }
@@ -1982,6 +1982,8 @@ void shutdown_app(void)
 	if(!g_context.args.script)
 	{
 		rl_callback_handler_remove();
+		free(rl_basic_word_break_characters);
+		free(rl_completer_word_break_characters);
 	}
 }
 


### PR DESCRIPTION
`readline` on OSX is provided by `libedit`, which does not provide `rl_completion_display_matches_hook` - a clumsy, but functional, workaround is to `#ifndef __APPLE__ [...] #endif` that assignment. The program still works, from what I can tell.

In addition, assigning string constants to non-`const` `char*` variables is deprecated; `strdup()`ing and `free()`ing the string is a more appropriate way to do it.
