### PR TITLE
Fix udev rule not working

### DIFF
--- a/usbhostfs_pc/50-psplink.rules
+++ b/usbhostfs_pc/50-psplink.rules
@@ -1,1 +1,1 @@
-SUBSYSTEM=="usb_device", SYSFS{idVendor}=="054c", SYSFS{idProduct}=="01c9"  MODE="0666"
+SUBSYSTEM=="usb", SYSFS{idVendor}=="054c", SYSFS{idProduct}=="01c9", MODE="0666"

--- a/usbhostfs_pc/50-psplink.rules
+++ b/usbhostfs_pc/50-psplink.rules
@@ -1,1 +1,1 @@
-SUBSYSTEM=="usb", SYSFS{idVendor}=="054c", SYSFS{idProduct}=="01c9", MODE="0666"
+SUBSYSTEM=="usb", ATTR{idVendor}=="054c", ATTR{idProduct}=="01c9", SYMLINK+="psp", MODE="0666"


### PR DESCRIPTION
The udev rule was using the wrong subsystem and missing a comma, causing it not to work. With this change it can be used.