### PR TITLE
Show the address when an exception occures

### DIFF
--- a/psplink/exception.c
+++ b/psplink/exception.c
@@ -246,6 +246,7 @@ void exceptionPrint(struct PsplinkContext *ctx)
 		}
 
 		SHELL_PRINT("Status    - 0x%08X\n", ctx->regs.status);
+		SHELL_PRINT("Address   - 0x%08X\n", ctx->regs.epc-mod.text_addr);
 		exceptionPrintCPURegs(ctx->regs.r);
 	}
 	else


### PR DESCRIPTION
This address can be used with psp-addr2line to find out on which line
the application crashes. With this change users no longer need to run ``calc $epc-$mod`` everytime a crash happens to find this.