### PR TITLE
Fix building pspsh

### DIFF
--- a/pspsh/Makefile
+++ b/pspsh/Makefile
@@ -8,8 +8,11 @@ PREFIX=$(shell psp-config --pspdev-path 2> /dev/null)
 
 all: $(OUTPUT)
 
+%.o: %.c
+	$(CXX) -c -o $@ $< $(CXXFLAGS)
+
 $(OUTPUT): $(OBJS)
-	$(CXX) -o $@ $^ $(LIBS)
+	$(CXX) -o $@ $^ $(LIBS) $(CXXFLAGS)
 
 install: $(OUTPUT)
 	@echo "Installing $(OUTPUT)..."


### PR DESCRIPTION
Tested on alpine and macOS.

Error:
```
make -C pspsh all
make[1]: Entering directory '/src/psptoolchain/build/psplinkusb/pspsh'
cc    -c -o pspsh.o pspsh.c
cc    -c -o parse_args.o parse_args.c
cc    -c -o pspkerror.o pspkerror.c
cc    -c -o asm.o asm.c
cc    -c -o disasm.o disasm.c
pspsh.c:25:10: fatal error: shellcmd.h: No such file or directory
   25 | #include <shellcmd.h>
      |          ^~~~~~~~~~~~
compilation terminated.
make[1]: *** [<builtin>: pspsh.o] Error 1
make[1]: *** Waiting for unfinished jobs....
In file included from disasm.c:14:
disasm.h:10:10: fatal error: map: No such file or directory
   10 | #include <map>
      |          ^~~~~
compilation terminated.
make[1]: *** [<builtin>: disasm.o] Error 1
make[1]: Leaving directory '/src/psptoolchain/build/psplinkusb/pspsh'
make: *** [Makefile.clients:3: all] Error 2
../scripts/009-psplinkusb.sh: Failed.
```

Without PR:
```
cc    -c -o pspsh.o pspsh.c
cc    -c -o parse_args.o parse_args.c
cc    -c -o pspkerror.o pspkerror.c
cc    -c -o asm.o asm.c
cc    -c -o disasm.o disasm.c
c++ -o pspsh pspsh.o parse_args.o pspkerror.o asm.o disasm.o -lreadline -lcurses
```

With PR:
```
g++ -c -o pspsh.o pspsh.c -Wall -g -D_PCTERM -I../psplink
g++ -c -o parse_args.o parse_args.c -Wall -g -D_PCTERM -I../psplink
g++ -c -o pspkerror.o pspkerror.c -Wall -g -D_PCTERM -I../psplink
g++ -c -o asm.o asm.c -Wall -g -D_PCTERM -I../psplink
g++ -c -o disasm.o disasm.c -Wall -g -D_PCTERM -I../psplink
g++ -o pspsh pspsh.o parse_args.o pspkerror.o asm.o disasm.o -lreadline -lcurses -Wall -g -D_PCTERM -I../psplink
```