### PR TITLE
fix: docker build error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,4 @@ pspsh/pspsh
 tools/remotejoy/pcsdl/remotejoy
 tools/remotejoy/pc/remotejoy
 usbhostfs_pc/usbhostfs_pc
+release

--- a/usbgdb/main.c
+++ b/usbgdb/main.c
@@ -114,7 +114,7 @@ int initialise(SceSize args, void *argp)
         
         int t_pommel;
         
-        int t_result = sceSysconGetPommelVersion(&t_pommel);
+        int t_result = sceSyscon_driver_E7E87741(&t_pommel);
         
         if ((t_pommel >= 0x123) && (t_result == 0)) // If PSP 2000 or newer allow 64MB to be peeked and poked instead of 32MB
             g_userend = 0x0C000000;


### PR DESCRIPTION
I found https://github.com/pspdev/psplinkusb/issues/7 when building HEAD with the [PSP debugging guide]( https://bmaupin.github.io/wiki/other/psp/psp-debugging.html) using docker. This workaround mentioned in the discussion works.