### PR TITLE
Fix Windows build

### DIFF
--- a/pspsh/CMakeLists.txt
+++ b/pspsh/CMakeLists.txt
@@ -1,0 +1,24 @@
+cmake_minimum_required(VERSION 3.0)
+
+project(pspsh)
+
+add_compile_options(-Wall -D_PCTERM)
+
+set(SOURCES
+    pspsh.cpp
+    parse_args.cpp
+    pspkerror.cpp
+    asm.cpp
+    disasm.cpp 
+)
+
+add_executable(${PROJECT_NAME} ${SOURCES})
+
+target_link_libraries(${PROJECT_NAME}
+    readline
+    ncurses
+)
+
+target_include_directories(${PROJECT_NAME} PRIVATE
+    ${CMAKE_SOURCE_DIR}/../psplink
+)

--- a/usbhostfs_pc/CMakeLists.txt
+++ b/usbhostfs_pc/CMakeLists.txt
@@ -1,0 +1,20 @@
+cmake_minimum_required(VERSION 3.0)
+
+project(usbhostfs_pc)
+
+add_compile_options(-Wall -ggdb -DPC_SIDE -D_FILE_OFFSET_BITS=64)
+
+set(SOURCES
+    main.c 
+)
+
+add_executable(${PROJECT_NAME} ${SOURCES})
+
+target_link_libraries(${PROJECT_NAME}
+    usb
+    pthread
+)
+
+target_include_directories(${PROJECT_NAME} PRIVATE
+    ${CMAKE_SOURCE_DIR}/../usbhostfs
+)


### PR DESCRIPTION
This is still early at the moment, that's why it's a draft.

What I want to do is make pspsh and usbhostfs_pc buildable for Windows in the CI. This should be doable with the use of cmake and vcpkg.

Step one, to make them buildable with cmake is completed as of the making of this PR. Windows support in the cmake files is still WIP.