### PR TITLE
Fix qfThreadinfo response when user module has no threads.

### DIFF
--- a/usbgdb/gdb-stub.c
+++ b/usbgdb/gdb-stub.c
@@ -354,6 +354,10 @@ static void handle_query(struct PsplinkContext *ctx, char *str)
 						sprintf(output, "m%08X", threads[thread_loc]);
 						thread_loc++;
 					}
+					else
+					{
+						strcpy(output, "l");
+					}
 				}
 				break;
 


### PR DESCRIPTION
Returning an empty response (instead of empty thread list) messes around
with gdb's (recent versions of gdb at least) thread info detection. It
will fall back to the legacy methods (qL thread listing) which psplink
does not support, thus causing many issues.