### PR TITLE
Add more logging to wait usb device

### DIFF
--- a/usbhostfs_pc/main.c
+++ b/usbhostfs_pc/main.c
@@ -2023,11 +2023,32 @@ usb_dev_handle *wait_for_device(void)
 		usb_find_busses();
 		usb_find_devices();
 
-		hDev = open_device(usb_get_busses());
-		if(hDev)
+		struct usb_bus * busses = usb_get_busses();
+
+		if (!busses)
 		{
-			fprintf(stderr, "Connected to device\n");
-			break;
+			fprintf(stderr, "no busses found\n");
+		}
+		else
+		{
+			hDev = open_device(busses);
+			if(hDev)
+			{
+				fprintf(stderr, "Connected to device\n");
+				break;
+			}
+		
+			if (!hDev)
+			{
+				fprintf(stderr, "waiting for device...\n");
+			}
+
+			hDev = open_device(usb_get_busses());
+			if(hDev)
+			{
+				fprintf(stderr, "Connected to device\n");
+				break;
+			}
 		}
 
 		/* Sleep for one second */


### PR DESCRIPTION
this adds a bit more logging to the usb wait device

it will print "no busses found" if no usb busses can be found

it will print "waiting for device..." if the device cannot be found