### PR TITLE
Removed NCurses from workflow and makefiles as not required

### DIFF
--- a/.github/workflows/compilation.yml
+++ b/.github/workflows/compilation.yml
@@ -41,7 +41,7 @@ jobs:
         uses: egor-tensin/setup-cygwin@v3
         with:
           platform: x64
-          packages: gcc-core gcc-g++ make libreadline7 libreadline-devel libncursesw10 libncurses-devel libusb0 libusb-devel
+          packages: gcc-core gcc-g++ make libreadline7 libreadline-devel libusb0 libusb-devel
 
       - name: Compile project
         run: |
@@ -55,7 +55,6 @@ jobs:
           cp C:\tools\cygwin\bin\cyggcc_s-seh-1.dll build
           cp C:\tools\cygwin\bin\cygreadline7.dll build
           cp C:\tools\cygwin\bin\cygusb0.dll build
-          cp C:\tools\cygwin\bin\cygncursesw-10.dll build
 
       - name: Upload artifacts
         if: ${{ success() }}

--- a/pspsh/Makefile
+++ b/pspsh/Makefile
@@ -8,7 +8,7 @@ else
 endif
 
 CXXFLAGS+= -Wall -D_PCTERM -I../psplink
-LIBS=-lreadline -lcurses
+LIBS=-lreadline
 
 PREFIX=$(shell psp-config --pspdev-path 2> /dev/null)
 

--- a/ttylink/Makefile
+++ b/ttylink/Makefile
@@ -2,7 +2,7 @@ OUTPUT=ttylink
 OBJS=ttylink.o
 
 CFLAGS=-Wall -g 
-LIBS=-lreadline -lcurses
+LIBS=-lreadline
 
 all: ttylink
 

--- a/usbhostfs_pc/Makefile
+++ b/usbhostfs_pc/Makefile
@@ -16,7 +16,7 @@ endif
 
 ifdef READLINE_SHELL
 CFLAGS += -DREADLINE_SHELL
-LIBS += -lreadline -lcurses
+LIBS += -lreadline
 endif
 
 all: $(OUTPUT)


### PR DESCRIPTION
Tested by myself and @sharkwouter, we have discovered that ncurses is no longer needed for PSPLinkusb dropping the dependency 