### PR TITLE
Revert "Remove atoi function in shell.c to use builtin"

### DIFF
--- a/psplink/shell.c
+++ b/psplink/shell.c
@@ -1998,6 +1998,24 @@ static int remap_cmd(int argc, char **argv, unsigned int *vRet)
 	return CMD_OK;
 }
 
+// Iterative function to implement `atoi()` function in C
+int atoi(const char* S)
+{
+    long num = 0;
+ 
+    int i = 0;
+ 
+    // run till the end of the string is reached, or the
+    // current character is non-numeric
+    while (S[i] && (S[i] >= '0' && S[i] <= '9'))
+    {
+        num = num * 10 + (S[i] - '0');
+        i++;
+    }
+ 
+    return num;
+}
+
 static int meminfo_cmd(int argc, char **argv, unsigned int *vRet)
 {
 	int i;


### PR DESCRIPTION
Seems this was needed after all, unfortunately. I'm really surprised we don't have atoi.