### PR TITLE
Fix Hi/Lo registers corruption in exception handlers

### DIFF
--- a/psplink/exception_asm.S
+++ b/psplink/exception_asm.S
@@ -504,6 +504,12 @@ psplinkExceptionHandler:
 	lw		$30, REG_GPR_30($v0)
 	lw		$31, REG_GPR_31($v0)
 
+# Restore HI/LO regs
+	lw		$1,  REG_LO($v0)
+	mtlo	$1
+	lw		$1,  REG_HI($v0)
+	mthi	$1
+
 	lw		$1,  REG_EPC($v0)
 	mtc0    $1,  EPC
 


### PR DESCRIPTION
The registers are indeed save correctly (and passed around to the relevant contexts when needed) but not restored correctly.

This causes some bugs when single steping over code (can be either C or assembly code). It is easy to reproduce in C code but trival on assembly codebases (steping over mul/div will trash the HI/LO registers 99% of the time).