### PR TITLE
Fix `_exit` issue

### DIFF
--- a/bootstrap/main.c
+++ b/bootstrap/main.c
@@ -79,3 +79,9 @@ int module_start(SceSize args, void *argp)
 
 	return 0;
 }
+
+// Define _exit too, this is needed because this module is quite messy as it is using some functions from newlib
+void _exit(int status)
+{
+	sceKernelExitGame();
+}


### PR DESCRIPTION
## Description
This PR is required after improving `exit` flow in `pspsdk` 
https://github.com/pspdev/pspsdk/pull/222

The reason why now is this required is because `_exit` definition has been moved to `crt0` and `crt0_prx` files.
In theory, this is totally right, however, the `bootstrap` module being used here, is quite messy. 
When generating a `prx` if you define the function `module_start` the whole `ctr0_prx` will be skipped, then the boostrap module uses some functions from `newlib`, and these functions from newlib ends needing `_exit`, which wasn't included because `crt0_prx` was skipped.

I'm not sure if we should move `_end` out of the `crt0` and `crt0_prx`, I don't think so, however, I'm pretty sure that the issue we are suffering is an edge case, so I think we shouldn't worry that much for now...


Cheers.