### PR TITLE
Fix MacOS build in GitHub Actions

### DIFF
--- a/.github/workflows/host_tools.yml
+++ b/.github/workflows/host_tools.yml
@@ -37,12 +37,6 @@ jobs:
         sudo apt-get update
         sudo apt-get -y install libusb-1.0-0-dev libusb-dev gcc
 
-    - name: Install macOS packages
-      if: startsWith(matrix.os[0], 'macos')
-      run: |
-        brew update
-        brew install libusb gcc
-
     - name: Compile tools
       run: |
         make --quiet -j $PROC_NR -C usbhostfs_pc


### PR DESCRIPTION
The MacOS build was failing, because it was failing to reinstall dependencies which are already installed on the runner by default. I removed the step to install dependencies, since we already have everything.