### PR TITLE
Only run publish in CI step for tags and the master branch

### DIFF
--- a/.github/workflows/compilation.yml
+++ b/.github/workflows/compilation.yml
@@ -69,6 +69,7 @@ jobs:
   publish:
     needs: [build, windows]
     runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/')
     steps:
     - uses: actions/download-artifact@v4
 


### PR DESCRIPTION
For some reason it was running the zipping step for branches, but since it doesn't publish the artifacts from this step it is a bit useless. With this change it will just be skipped on off branches.